### PR TITLE
New voucher features

### DIFF
--- a/Data/Customer.cs
+++ b/Data/Customer.cs
@@ -46,5 +46,10 @@ namespace Cinema.Data
 
 			return newCustomer;
 		}
+
+		public override string ToString()
+		{
+			return $"Username: {Username}, Email: {Email}";
+		}
 	}
 }

--- a/Data/PercentVoucher.cs
+++ b/Data/PercentVoucher.cs
@@ -1,9 +1,8 @@
 class PercentVoucher : Voucher
 {
-    public PercentVoucher(string code, double discount) : base(code, discount) 
+    public PercentVoucher(string code, double discount, DateTimeOffset expDate, string customerEmail) : base(code, discount, expDate, customerEmail) 
     { 
         DiscountType = "%";
-
     }
     public override double ApplyDiscount(double price)
     {

--- a/Data/PercentVoucher.cs
+++ b/Data/PercentVoucher.cs
@@ -4,10 +4,17 @@ class PercentVoucher : Voucher
     { 
         DiscountType = "%";
     }
+    public PercentVoucher(string code, double discount, DateTimeOffset expirationDate, string customerEmail, string isreward) : this(code, discount, expirationDate, customerEmail)
+    {
+        IsReward = isreward;
+    } 
     public override double ApplyDiscount(double price)
     {
+        double olddiscount = Discount;
         Discount = price * (Discount / 100);
-        return base.ApplyDiscount(price);
+        double returnvalue = base.ApplyDiscount(price);
+        Discount = olddiscount;
+        return returnvalue;
     }
     public override string ToString() => $"Code: '{Code}', Korting {Discount}%, Vervaldatum: '{ExpirationDate.ToString("dd-MM-yyyy HH:mm")}, Gebonden aan Klant met Email: '{CustomerEmail}'";
 } 

--- a/Data/PercentVoucher.cs
+++ b/Data/PercentVoucher.cs
@@ -9,5 +9,5 @@ class PercentVoucher : Voucher
         Discount = price * (Discount / 100);
         return base.ApplyDiscount(price);
     }
-    public override string ToString() => $"Code: '{Code}', Korting {Discount}%";
+    public override string ToString() => $"Code: '{Code}', Korting {Discount}%, Vervaldatum: '{ExpirationDate.ToString("dd-MM-yyyy HH:mm")}, Gebonden aan Klant met Email: '{CustomerEmail}'";
 } 

--- a/Data/Voucher.cs
+++ b/Data/Voucher.cs
@@ -4,15 +4,20 @@ public class Voucher
     public int Id { get; set; }
     public string Code { get; set; }
     public double Discount { get; set; }
+    public bool Active { get; set; } = true;
     public string DiscountType { get; set; } = "-";
-    public Voucher(string code, double discount)
+    public DateTimeOffset ExpirationDate { get; set; }
+    public string CustomerEmail { get; set; }
+    public Voucher(string code, double discount, DateTimeOffset expirationDate, string customerEmail)
     {
         Code = code;
         Discount = Math.Round(Math.Round(discount / 0.05) * 0.05, 3);
+        ExpirationDate = expirationDate;
+        CustomerEmail = customerEmail;
     }
     public virtual double ApplyDiscount(double price)
     {
         return price - Discount < 0 ? 0 : price - Discount;
     }
-    public override string ToString() => $"Code: '{Code}', Korting {Discount},-";
+    public override string ToString() => $"Code: '{Code}', Korting {Discount},-, Vervaldatum: '{ExpirationDate.ToString("dd-MM-yyyy HH:mm")}, Gebonden aan Klant met Email: '{CustomerEmail}'";
 }

--- a/Data/Voucher.cs
+++ b/Data/Voucher.cs
@@ -8,6 +8,7 @@ public class Voucher
     public string DiscountType { get; set; } = "-";
     public DateTimeOffset ExpirationDate { get; set; }
     public string CustomerEmail { get; set; }
+    public string IsReward { get; set; } = "false";
     public Voucher(string code, double discount, DateTimeOffset expirationDate, string customerEmail)
     {
         Code = code;
@@ -15,6 +16,11 @@ public class Voucher
         ExpirationDate = expirationDate;
         CustomerEmail = customerEmail;
     }
+
+    public Voucher(string code, double discount, DateTimeOffset expirationDate, string customerEmail, string isreward) : this(code, discount, expirationDate, customerEmail)
+    {
+        IsReward = isreward;
+    } 
     public virtual double ApplyDiscount(double price)
     {
         return price - Discount < 0 ? 0 : price - Discount;

--- a/Migrations/20240516074816_AddDate+EmailToVouchers.Designer.cs
+++ b/Migrations/20240516074816_AddDate+EmailToVouchers.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Cinema.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace cinema.Migrations
 {
     [DbContext(typeof(CinemaContext))]
-    partial class CinemaContextModelSnapshot : ModelSnapshot
+    [Migration("20240516074816_AddDate+EmailToVouchers")]
+    partial class AddDateEmailToVouchers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240516074816_AddDate+EmailToVouchers.cs
+++ b/Migrations/20240516074816_AddDate+EmailToVouchers.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace cinema.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDateEmailToVouchers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerEmail",
+                table: "Vouchers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ExpirationDate",
+                table: "Vouchers",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CustomerEmail",
+                table: "Vouchers");
+
+            migrationBuilder.DropColumn(
+                name: "ExpirationDate",
+                table: "Vouchers");
+        }
+    }
+}

--- a/Migrations/CinemaContextModelSnapshot.cs
+++ b/Migrations/CinemaContextModelSnapshot.cs
@@ -136,7 +136,7 @@ namespace cinema.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<DateTimeOffset>("CancelledAt")
+                    b.Property<DateTimeOffset?>("CancelledAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CustomerEmail")
@@ -218,6 +218,9 @@ namespace cinema.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
                     b.Property<string>("Code")
                         .HasColumnType("text");
 
@@ -232,6 +235,9 @@ namespace cinema.Migrations
 
                     b.Property<DateTimeOffset>("ExpirationDate")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsReward")
+                        .HasColumnType("boolean");
 
                     b.HasKey("Id");
 

--- a/Models/Choices/CinemaManagementVoucherChoice.cs
+++ b/Models/Choices/CinemaManagementVoucherChoice.cs
@@ -10,6 +10,9 @@ namespace Cinema.Models.Choices
         [Display(Name = "Verwijder een bestaande voucher")]
         DeleteVoucher,
 
+        [Display(Name = "Wijzig een bestaande voucher")]
+        ChangeVoucher,
+
         [Display(Name = "Terug")]
         Exit
     }

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -545,6 +545,7 @@ namespace Cinema.Services
             );
             if (stringvouchertodelete == "Terug")
             {
+                Voucherpanel(db);
                 return;
             }
             Console.Clear();
@@ -583,6 +584,7 @@ namespace Cinema.Services
             );
             if (stringvoucher == "Terug")
             {
+                Voucherpanel(db);
                 return;
             }
 
@@ -598,6 +600,8 @@ namespace Cinema.Services
             );
             if (option == "Terug")
             {
+                Console.Clear(); 
+                ChangeExistingVoucher(db);
                 return;
             }
             Console.Clear();  
@@ -696,6 +700,7 @@ namespace Cinema.Services
             AnsiConsole.Markup("[green]Voucher succesvol opgeslagen![/]");
             AnsiConsole.WriteLine("\nDruk op een toets om terug te gaan....");
             Console.ReadKey();
+            Voucherpanel(db);
         }
     }
 }

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -86,7 +86,7 @@ namespace Cinema.Services
             Console.Clear();
 
             var movies = db.Movies.ToList();
-            var options = movies.Select(movie => movie.Title).ToList();
+            var options = movies.Select(movie => movie.Title).OrderBy(x => x).ToList();
             options.Insert(0, "Terug");
 
             var selectedOption = AnsiConsole.Prompt(
@@ -624,7 +624,9 @@ namespace Cinema.Services
                     .PromptStyle("yellow")
                 );
                 double discount = discountType.Contains("%") ? LogicLayerVoucher.CheckPercentDiscount(stringdiscount) : LogicLayerVoucher.CheckDiscount(stringdiscount);
-                voucher.Discount = discount;
+                db.Vouchers.Remove(voucher);
+                voucher = discountType.Contains("%") ? new PercentVoucher(voucher.Code, discount, voucher.ExpirationDate, voucher.CustomerEmail) : new Voucher(voucher.Code, discount, voucher.ExpirationDate, voucher.CustomerEmail);
+                db.Vouchers.Add(voucher);
             }
             else if (option.Contains("datum"))
             {
@@ -674,6 +676,7 @@ namespace Cinema.Services
                 return;
 
             db.SaveChanges();
+            UpdateVouchers(db);
             AnsiConsole.Markup("[green]Voucher succesvol opgeslagen![/]");
             AnsiConsole.WriteLine("\nDruk op een toets om terug te gaan....");
             Console.ReadKey();

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -536,15 +536,19 @@ namespace Cinema.Services
 
         public static void DeleteVoucher(CinemaContext db)
         {
-            List<Voucher> vouchers = db.Vouchers.Where(x => x.IsReward == "false").ToList();
-            Voucher vouchertodelete = AnsiConsole.Prompt(
-                new SelectionPrompt<Voucher>()
+            List<string> vouchers = db.Vouchers.Where(x => x.IsReward == "false").Select(x => $"{x}").ToList();
+            vouchers.Add("Terug");
+            string stringvouchertodelete = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
                     .Title("Selecteer een voucher om te verwijderen:")
                     .AddChoices(vouchers)
             );
-
+            if (stringvouchertodelete == "Terug")
+            {
+                return;
+            }
             Console.Clear();
-
+            Voucher vouchertodelete = db.Vouchers.AsEnumerable().FirstOrDefault(x => x.ToString() == stringvouchertodelete);
             AnsiConsole.Markup($"[blue]Gekozen Voucher: {vouchertodelete.ToString()}[/]\n");
             bool ready = AnsiConsole.Confirm("Weet je zeker dat je deze voucher wilt verwijderen?");
             if (!ready)
@@ -570,22 +574,32 @@ namespace Cinema.Services
         {
             string option;
             string code;
-            List<Voucher> vouchers = db.Vouchers.Where(x => x.IsReward == "false").ToList();
-            Voucher voucher = AnsiConsole.Prompt(
-                new SelectionPrompt<Voucher>()
-                    .Title("Selecteer een voucher om te wijzigen")
+            List<string> vouchers = db.Vouchers.Where(x => x.IsReward == "false").Select(x => $"{x}").ToList();
+            vouchers.Add("Terug");
+            string stringvoucher = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Selecteer een voucher om te verwijderen:")
                     .AddChoices(vouchers)
             );
+            if (stringvoucher == "Terug")
+            {
+                return;
+            }
 
             Console.Clear();
+            Voucher voucher = db.Vouchers.AsEnumerable().FirstOrDefault(x => x.ToString() == stringvoucher);
 
             AnsiConsole.Markup($"[blue]Gekozen Voucher: {voucher.ToString()}[/]\n");
 
             option = AnsiConsole.Prompt(
                 new SelectionPrompt<string>()
                     .Title("Selecteer wat u wilt wijzigen aan deze voucher:")
-                    .AddChoices(new[] { "Code", "Korting(prijs en type)", "Vervaldatum", "Klant"})
+                    .AddChoices(new[] { "Code", "Korting(prijs en type)", "Vervaldatum", "Klant", "Terug"})
             );
+            if (option == "Terug")
+            {
+                return;
+            }
             Console.Clear();  
             if (option.Contains("Code"))
             {

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -560,10 +560,9 @@ namespace Cinema.Services
         public static void UpdateVouchers(CinemaContext db)
         {
             List<Voucher> expiredvouchers = db.Vouchers.Where(x => DateTimeOffset.UtcNow > x.ExpirationDate.UtcDateTime.AddHours(-2)).ToList();
-            foreach (Voucher voucher in expiredvouchers)
-            {
-                voucher.Active = false;
-            }
+            List<Voucher> indatevouchers = db.Vouchers.Where(x => DateTimeOffset.UtcNow <= x.ExpirationDate.UtcDateTime.AddHours(-2)).ToList();
+            foreach (Voucher voucher in expiredvouchers) voucher.Active = false;
+            foreach (Voucher voucher in indatevouchers) voucher.Active = true;
             db.SaveChanges();
         }
 

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -624,8 +624,10 @@ namespace Cinema.Services
                     .PromptStyle("yellow")
                 );
                 double discount = discountType.Contains("%") ? LogicLayerVoucher.CheckPercentDiscount(stringdiscount) : LogicLayerVoucher.CheckDiscount(stringdiscount);
+                int id = voucher.Id;
                 db.Vouchers.Remove(voucher);
                 voucher = discountType.Contains("%") ? new PercentVoucher(voucher.Code, discount, voucher.ExpirationDate, voucher.CustomerEmail) : new Voucher(voucher.Code, discount, voucher.ExpirationDate, voucher.CustomerEmail);
+                voucher.Id = id;
                 db.Vouchers.Add(voucher);
             }
             else if (option.Contains("datum"))

--- a/Presentation/PresentAdminOptions.cs
+++ b/Presentation/PresentAdminOptions.cs
@@ -536,7 +536,7 @@ namespace Cinema.Services
 
         public static void DeleteVoucher(CinemaContext db)
         {
-            List<Voucher> vouchers = db.Vouchers.ToList();
+            List<Voucher> vouchers = db.Vouchers.Where(x => x.IsReward == "false").ToList();
             Voucher vouchertodelete = AnsiConsole.Prompt(
                 new SelectionPrompt<Voucher>()
                     .Title("Selecteer een voucher om te verwijderen:")
@@ -570,7 +570,7 @@ namespace Cinema.Services
         {
             string option;
             string code;
-            List<Voucher> vouchers = db.Vouchers.ToList();
+            List<Voucher> vouchers = db.Vouchers.Where(x => x.IsReward == "false").ToList();
             Voucher voucher = AnsiConsole.Prompt(
                 new SelectionPrompt<Voucher>()
                     .Title("Selecteer een voucher om te wijzigen")

--- a/Presentation/PresentCustomerOptions.cs
+++ b/Presentation/PresentCustomerOptions.cs
@@ -19,7 +19,7 @@ public static class PresentCustomerOptions
             new SelectionPrompt<string>()
                 .Title("")
                 .PageSize(10)
-                .AddChoices(new[] { "Bladeren door films", "Reserveringen bekijken", "Account beheren", "Log Uit" })
+                .AddChoices(new[] { "Bladeren door films", "Reserveringen bekijken", "Reservatie Progress Bekijken", "Account beheren", "Log Uit" })
         );
         switch (optionChoice)
         {
@@ -28,6 +28,9 @@ public static class PresentCustomerOptions
                 break;
             case "Reserveringen bekijken":
                 PresentReservations.Start(loggedInCustomer, db);
+                break;
+            case "Reservatie Progress Bekijken":
+                PresentCustomerReservationProgress.Start(loggedInCustomer, db);
                 break;
             case "Account beheren":
                 AnsiConsole.Clear();

--- a/Presentation/PresentCustomerOptions.cs
+++ b/Presentation/PresentCustomerOptions.cs
@@ -7,6 +7,7 @@ public static class PresentCustomerOptions
     public static void Start(Customer loggedInCustomer, CinemaContext db)
     {
         UserExperienceService user = new UserExperienceService();
+        PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
         AnsiConsole.Clear();
         var rule = new Rule("[bold blue]Klanten opties:[/]")
         {

--- a/Presentation/PresentCustomerOptions.cs
+++ b/Presentation/PresentCustomerOptions.cs
@@ -8,8 +8,8 @@ public static class PresentCustomerOptions
     public static void Start(Customer loggedInCustomer, CinemaContext db)
     {
         UserExperienceService user = new UserExperienceService();
-        PresentAdminOptions.UpdateVouchers(db);
         PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+        PresentAdminOptions.UpdateVouchers(db);
         AnsiConsole.Clear();
         var rule = new Rule("[bold blue]Klanten opties:[/]")
         {

--- a/Presentation/PresentCustomerOptions.cs
+++ b/Presentation/PresentCustomerOptions.cs
@@ -1,4 +1,5 @@
 using Cinema.Data;
+using Cinema.Services;
 using Spectre.Console;
 
 public static class PresentCustomerOptions
@@ -7,6 +8,7 @@ public static class PresentCustomerOptions
     public static void Start(Customer loggedInCustomer, CinemaContext db)
     {
         UserExperienceService user = new UserExperienceService();
+        PresentAdminOptions.UpdateVouchers(db);
         PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
         AnsiConsole.Clear();
         var rule = new Rule("[bold blue]Klanten opties:[/]")

--- a/Presentation/PresentCustomerReservationProgress.cs
+++ b/Presentation/PresentCustomerReservationProgress.cs
@@ -129,6 +129,7 @@ public static class PresentCustomerReservationProgress
            if (vouchersWithReward != null)
            {
                 vouchersWithReward.IsReward = "false";
+                vouchersWithReward.ExpirationDate = DateTimeOffset.UtcNow.AddHours(1);
                 db.SaveChanges();
            }
 

--- a/Presentation/PresentCustomerReservationProgress.cs
+++ b/Presentation/PresentCustomerReservationProgress.cs
@@ -1,0 +1,103 @@
+using Cinema.Data;
+using Cinema.Services;
+using Spectre.Console;
+
+public static class PresentCustomerReservationProgress
+{
+
+    public static void Start(Customer customer, CinemaContext db)
+    {
+        PresentAdminOptions.UpdateVouchers(db);
+        AnsiConsole.Clear();
+        var rule = new Rule("[bold blue]Reservatie Progress:[/]")
+        {
+            Justification = Justify.Left,
+            Style = Style.Parse("blue")
+        };
+        AnsiConsole.Write(rule);
+        AnsiConsole.MarkupLine($"[bold blue]Hier kan je bekijken hoeveel reserveringen je verwijderd bent van het behalen van een verassing![/]");
+        AnsiConsole.MarkupLine($"[bold blue]Het gaat hier om het aantal reserveringen dat je voltooid hebt binnen 2 maanden![/]");
+        AnsiConsole.MarkupLine($"[bold blue]Bereik het aantal binnen 2 maanden en geniet van het voordeel![/]");
+        ReservationProgress(customer, db);
+        var optionChoice = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("")
+                .PageSize(10)
+                .AddChoices(new[] { "Terug" })
+            );
+        AnsiConsole.Clear();
+        PresentCustomerOptions.Start(customer, db);
+    }
+    public static void ReservationProgress(Customer customer, CinemaContext db)
+    {
+        DateTimeOffset today = DateTimeOffset.UtcNow.AddHours(2);
+        DateTimeOffset startdate;
+        Voucher v;
+        if (today.Month % 2 == 1)
+        {
+            startdate = new DateTimeOffset(today.Year, today.Month, 1, 0, 0, 0, today.Offset);
+        }
+        else
+        {
+            startdate = new DateTimeOffset(today.Year, today.Month - 1, 1, 0, 0, 0, today.Offset);
+        }
+        DateTimeOffset enddate = startdate.AddMonths(2).AddDays(-1);
+        double amount = db.Tickets.Where(x => x.CustomerEmail == customer.Email && x.PurchasedAt <= enddate && x.PurchasedAt >= startdate && (x.CancelledAt == null || x.CancelledAt == DateTimeOffset.MinValue)).Count();
+        if (amount == 0)
+        {
+           Voucher vouchersWithReward = db.Vouchers.FirstOrDefault(v => v.IsReward == "true" && v.CustomerEmail == customer.Email);
+           if (vouchersWithReward != null)
+           {
+                vouchersWithReward.IsReward = "false";
+                db.SaveChanges();
+           }
+
+        }
+        double max = 10;
+        RenderProgressBar(amount / max * 100);
+        AnsiConsole.MarkupLine($"[green]{amount} van de {max} reserveringen behaald! (tussen {startdate.ToString("dd-MM-yyyy")} en {enddate.ToString("dd-MM-yyyy")})[/]");
+        if (amount >= max)
+        {
+            Voucher check = db.Vouchers.FirstOrDefault(v => v.IsReward == "true" && v.CustomerEmail == customer.Email);
+            if (check != null)
+            {
+                v = check;
+            }
+            else
+            {
+                v = new PercentVoucher(LogicLayerVoucher.GenerateRandomCode(db), 10, DateTimeOffset.UtcNow.AddMonths(6).AddHours(2), customer.Email, "true");
+                db.Vouchers.Add(v);
+                db.SaveChanges();
+            }
+            if (!v.Active)
+            {
+                AnsiConsole.MarkupLine($"[green]Je hebt de verkregen Voucher successvol gebruikt! Tot de volgende campagne![/]");
+                return;
+            }
+            AnsiConsole.MarkupLine($"[green]Maak eenmalig gebruik van de VoucherCode '{v.Code}' om {v.Discount}% korting te krijgen bij je volgende boeking![/]");
+            return;
+        }
+        AnsiConsole.MarkupLine($"[grey]Nog {max - amount} boekingen over tot het behalen van een voordelige kortingscode![/]");
+    }
+
+    public static void RenderProgressBar(double percentage)
+    {
+        // Create a task description
+        var taskDescription = "[green]Progress[/]";
+
+        // Render the progress bar using the Spectre.Console Progress API
+        AnsiConsole.Progress()
+            .Columns(new ProgressColumn[]
+            {
+                new TaskDescriptionColumn(),    // Task description
+                new ProgressBarColumn(),        // Progress bar
+                new PercentageColumn()          // Percentage
+            })
+            .Start(ctx =>
+            {
+                // Add a task with the calculated progress
+                var task = ctx.AddTask(taskDescription);
+                task.Increment(percentage);
+            });
+    }
+}

--- a/Presentation/PresentGuestReservationLogin.cs
+++ b/Presentation/PresentGuestReservationLogin.cs
@@ -63,7 +63,6 @@ public class PresentGuestReservationLogin
         return AnsiConsole.Prompt(
             new TextPrompt<string>("Voer uw [bold blue]ticket nummer[/] in:")
                 .PromptStyle("blue")
-                .Secret()
                 .Validate(TicketNumber =>
                 {
                     if (string.IsNullOrWhiteSpace(TicketNumber))

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -312,7 +312,11 @@ public class UserExperienceService
         Console.Clear();
         AnsiConsole.Render(table);
 
-        Console.WriteLine($"Total Price: ${v.ApplyDiscount((double)totalSeatPrice)}");
+        Console.WriteLine($"Oude Totaal Price: ${totalSeatPrice}");
+        if (v is PercentVoucher) Console.WriteLine($"Voucher gebruikt: '{v.Code}' voor {v.Discount}% korting");
+        else Console.WriteLine($"Voucher gebruikt: '{v.Code}' voor -{v.Discount},- korting");
+
+        Console.WriteLine($"Nieuwe Totaal Price: ${v.ApplyDiscount((double)totalSeatPrice)}");
       }
     }
 

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -58,6 +58,7 @@ public class UserExperienceService
   public void ListMoviesWithShowtimes(Customer loggedInCustomer, CinemaContext db)
   {
     PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+    PresentAdminOptions.UpdateVouchers(db);
     Console.Clear();
 
     var moviesQuery = db.Movies.Include(m => m.Showtimes);

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -57,7 +57,7 @@ public class UserExperienceService
   [Obsolete]
   public void ListMoviesWithShowtimes(Customer loggedInCustomer, CinemaContext db)
   {
-    PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+    if (loggedInCustomer != null) PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
     PresentAdminOptions.UpdateVouchers(db);
     Console.Clear();
 
@@ -74,6 +74,7 @@ public class UserExperienceService
       var moviesWithUpcomingShowtimes = moviesQuery
           .Where(m => m.Showtimes != null && m.Showtimes
           .Any(s => s.StartTime >= DateTime.UtcNow && s.StartTime >= startOfWeek && s.StartTime < endOfWeek && s.StartTime >= DateTime.UtcNow + TimeSpan.FromHours(2)))
+          .OrderBy(x => x.Title)
           .ToList();
 
       var options = new List<string> { "Filter door films" };
@@ -120,8 +121,11 @@ public class UserExperienceService
       else if (selectedOption == "Filter door films")
       {
         var result = ApplyFilters(db);
-        moviesQuery = result.Item1.Include(m => m.Showtimes);
-        filterDescription = result.Item2;
+        if (!(result.Item1 == null))
+        {
+          moviesQuery = result.Item1.Include(m => m.Showtimes);
+          filterDescription = result.Item2;
+        }
         Console.Clear();
         continue;
       }
@@ -349,6 +353,8 @@ public class UserExperienceService
       }
       AnsiConsole.MarkupLine("[green]Seats successfully reserved.[/]");
       Console.WriteLine("Press any key to return to start.");
+      PresentAdminOptions.UpdateVouchers(db);
+      PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
       Console.ReadKey(true);
       Console.Clear();
     }

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -354,7 +354,7 @@ public class UserExperienceService
       AnsiConsole.MarkupLine("[green]Seats successfully reserved.[/]");
       Console.WriteLine("Press any key to return to start.");
       PresentAdminOptions.UpdateVouchers(db);
-      PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+      if (loggedInCustomer != null) PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
       Console.ReadKey(true);
       Console.Clear();
     }

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -57,6 +57,7 @@ public class UserExperienceService
   [Obsolete]
   public void ListMoviesWithShowtimes(Customer loggedInCustomer, CinemaContext db)
   {
+    PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
     Console.Clear();
 
     var moviesQuery = db.Movies.Include(m => m.Showtimes);
@@ -444,6 +445,7 @@ public class UserExperienceService
     if (voucherprompt.Contains("Yes"))
     {
       PresentAdminOptions.UpdateVouchers(db);
+      PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
       List<Voucher> availableVouchers = db.Vouchers.Where(x => x.Active == true && x.CustomerEmail == loggedInCustomer.Email).ToList();
       string voucherCode = AnsiConsole.Prompt(
         new TextPrompt<string>("Voer je voucher code in (of typ 'stop' om te stoppen):")

--- a/Services/UserExperienceService.cs
+++ b/Services/UserExperienceService.cs
@@ -309,7 +309,7 @@ public class UserExperienceService
     }
     AnsiConsole.Render(table);
 
-    Console.WriteLine($"Total Price: ${totalSeatPrice}");
+    Console.WriteLine($"Totaal Prijs: ${totalSeatPrice}");
     if (!(loggedInCustomer is null))
     {
       v = UseVoucher(db, loggedInCustomer);
@@ -318,11 +318,11 @@ public class UserExperienceService
         Console.Clear();
         AnsiConsole.Render(table);
 
-        Console.WriteLine($"Oude Totaal Price: ${totalSeatPrice}");
+        Console.WriteLine($"Oude Totaal Prijs: ${totalSeatPrice}");
         if (v is PercentVoucher) Console.WriteLine($"Voucher gebruikt: '{v.Code}' voor {v.Discount}% korting");
         else Console.WriteLine($"Voucher gebruikt: '{v.Code}' voor -{v.Discount},- korting");
 
-        Console.WriteLine($"Nieuwe Totaal Price: ${v.ApplyDiscount((double)totalSeatPrice)}");
+        Console.WriteLine($"Nieuwe Totaal Prijs: ${v.ApplyDiscount((double)totalSeatPrice)}");
       }
     }
 
@@ -353,8 +353,8 @@ public class UserExperienceService
       }
       AnsiConsole.MarkupLine("[green]Seats successfully reserved.[/]");
       Console.WriteLine("Press any key to return to start.");
-      PresentAdminOptions.UpdateVouchers(db);
       if (loggedInCustomer != null) PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+      PresentAdminOptions.UpdateVouchers(db);
       Console.ReadKey(true);
       Console.Clear();
     }
@@ -447,12 +447,12 @@ public class UserExperienceService
     new SelectionPrompt<string>()
         .PageSize(3)
         .AddChoices("Yes", "No")
-        .Title("Do you want to enter a vouchercode?")
+        .Title("Wilt u een vouchercode invoeren?")
         .HighlightStyle(new Style(Color.Blue)));
     if (voucherprompt.Contains("Yes"))
     {
-      PresentAdminOptions.UpdateVouchers(db);
       PresentCustomerReservationProgress.UpdateTrueProgress(loggedInCustomer, db);
+      PresentAdminOptions.UpdateVouchers(db);
       List<Voucher> availableVouchers = db.Vouchers.Where(x => x.Active == true && x.CustomerEmail == loggedInCustomer.Email).ToList();
       string voucherCode = AnsiConsole.Prompt(
         new TextPrompt<string>("Voer je voucher code in (of typ 'stop' om te stoppen):")


### PR DESCRIPTION
Nieuwe Features van deze branch:

- Admin kan nu vouchers maken waarbij hij een vervaldatum en gebonden klant aan mee kan geven

- Admin kan stukken van bestaande vouchers veranderen; dus bij van 20% -> 10% korting, of klant veranderen, vervaldatum verlengen etc

- Ingelogde klant krijgt bij het reserveren de optie om een voucher in te voeren voor korting. Zij kunnen dit stoppen wanneer zij willen. Bij een correct ingevoerde voucher (wanneer een voucher actief is en bij die klant behoord) wordt precies aangegeven welke voucher zij gebruikt hebben en hoe groot het verschil in prijs hierdoor is. Voucher wordt na gebruik tijdens reservatie automatisch vervallen (waarbij de admin hem weer kan reactiveren naar wens)

- Ingelogde klanten krijgen de optie om te zien hoeveel reservaties zij verwijderd zijn van het ontvangen van een voucher als reward. Dit wordt laten zien in een progress bar met daaronder ook tekst. Wanneer het aantal reservaties bereikt is komt onder de progress bar wat tekst te staan waarin de voucher staat met hoeveel procent er geschonken wordt. Dit tekst zal weggaan nadat de voucher gebruikt is. Er zit veel errorhandling in dit gedeeldte om behalen van doel, code noteren van voucher, en vervolgens reservaties cancellen te voorkomen.